### PR TITLE
bumped version to 1.8 and upgraded log4j to 2.17 because of security …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.eireglas</groupId>
     <artifactId>givwenzen</artifactId>
-    <version>1.8</version>
+    <version>1.9</version>
 
     <name>GivWenZen</name>
     <packaging>jar</packaging>
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>commons-vfs</groupId>


### PR DESCRIPTION
bumped version to 1.8 and upgraded log4j to 2.17 because of security issues